### PR TITLE
TAMAYA-374 version substitution in source blocks

### DIFF
--- a/content/documentation/extensions/mod_camel.adoc
+++ b/content/documentation/extensions/mod_camel.adoc
@@ -20,18 +20,17 @@ configuration with Apache Camel.
 === Compatibility
 
 The module is based on Java 8. 
-{jbake-tamaya_version}
 
 === Installation
 
 To benefit from configuration builder support you only must add the corresponding dependency to your module:
 
-[source, xml, subs="attributes"]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>
   <artifactId>tamaya-camel_beta</artifactId>
-  <version>{jbake-tamaya_version}</version>
+  <version>{tamaya_version}</version>
 </dependency>
 -----------------------------------------------
 

--- a/content/documentation/extensions/mod_cdi.adoc
+++ b/content/documentation/extensions/mod_cdi.adoc
@@ -36,6 +36,7 @@ The annotations used for all injection functionality in Tamaya is defined as a s
 code against the injection API without dependency on the concrete injection implementation. As a consequence your
 components will be compatible regardless if deployed in a pure SE or as Java EE (CDI) or Spring environment:
 
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>
@@ -56,7 +57,7 @@ To benefit from Tamaya CDI integration you only must one of the following depend
 you never have installed both CDI extensions at the same time because this may be lead to unforseen side-effects.
 
 .CDI Java EE Application Configuration
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>
@@ -69,7 +70,7 @@ you never have installed both CDI extensions at the same time because this may b
 following dependency. If this dependency is missing injection is purely based on
 CDI injection features.
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_classloader_support.adoc
+++ b/content/documentation/extensions/mod_classloader_support.adoc
@@ -29,7 +29,7 @@ The module is based on Java 7, so it will not run on Java 7 and beyond.
 
 To benefit from configuration server support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_collections.adoc
+++ b/content/documentation/extensions/mod_collections.adoc
@@ -27,7 +27,7 @@ The module requires Java 8.
 
 To use Tamaya collection support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_consul.adoc
+++ b/content/documentation/extensions/mod_consul.adoc
@@ -29,7 +29,7 @@ The module is based on Java 8.
 
 To use _tamaya-consul_ you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_etcd.adoc
+++ b/content/documentation/extensions/mod_etcd.adoc
@@ -28,7 +28,7 @@ The module is based on Java 8.
 To use _etcd_ as a configuration backend you only must add the corresponding dependency to
 your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_events.adoc
+++ b/content/documentation/extensions/mod_events.adoc
@@ -33,7 +33,7 @@ The module is based on Java 8.
 
 To benefit from configuration event support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_features.adoc
+++ b/content/documentation/extensions/mod_features.adoc
@@ -25,7 +25,7 @@ The module is based on Java 7, so it will not run on Java 7 and beyond.
 To use Tamaya _Features_ you only must add the corresponding dependency to
 your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_filter.adoc
+++ b/content/documentation/extensions/mod_filter.adoc
@@ -29,7 +29,7 @@ The module is based on Java 8.
 
 To benefit from filter support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_formats.adoc
+++ b/content/documentation/extensions/mod_formats.adoc
@@ -30,7 +30,7 @@ The module is based on Java 8.
 
 To use the formats module you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_functions.adoc
+++ b/content/documentation/extensions/mod_functions.adoc
@@ -35,7 +35,7 @@ The module is based on Java 7, so it can be used with Java 7 and beyond.
 
 For using the functionality shown in this document you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_hazelcast.adoc
+++ b/content/documentation/extensions/mod_hazelcast.adoc
@@ -30,7 +30,7 @@ The module is based on Java 8.
 
 To use _tamaya-hazelcast_ you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_injection.adoc
+++ b/content/documentation/extensions/mod_injection.adoc
@@ -29,7 +29,7 @@ The module is based on Java 7, so it can be used with Java 7 and beyond.
 
 Basically Tamaya's injection API is deployed as API artifact:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>
@@ -40,7 +40,7 @@ Basically Tamaya's injection API is deployed as API artifact:
 
 To use injection with Java SE you must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_jndi.adoc
+++ b/content/documentation/extensions/mod_jndi.adoc
@@ -26,7 +26,7 @@ The module is based on Java 8.
 To use _jndi_ as a configuration backend you only must add the corresponding dependency to
 your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_jodatime.adoc
+++ b/content/documentation/extensions/mod_jodatime.adoc
@@ -21,7 +21,7 @@ converters to use Joda-Time types when accessing configuration.
 To support Joda-Time types as configuration values, you only have to add the following
 maven dependency to your project:
 
-[source, listing]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <grooupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_json.adoc
+++ b/content/documentation/extensions/mod_json.adoc
@@ -46,7 +46,7 @@ The module is based on Java 8.
 
 To use the JSON extension module you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_management.adoc
+++ b/content/documentation/extensions/mod_management.adoc
@@ -25,7 +25,7 @@ The module is based on Java 7, so it will run on Java 7 and beyond.
 To use the _management_ extension you only must add the corresponding dependency
 to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_metamodel.adoc
+++ b/content/documentation/extensions/mod_metamodel.adoc
@@ -78,7 +78,7 @@ The module is based on Java 8.
 
 To use _metamodel_ features you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_microprofile.adoc
+++ b/content/documentation/extensions/mod_microprofile.adoc
@@ -33,7 +33,7 @@ version 1.1.
 
 To benefit from Tamaya Microprofile you only must one of the following dependencies to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_mutable_config.adoc
+++ b/content/documentation/extensions/mod_mutable_config.adoc
@@ -28,7 +28,7 @@ The module is based on Java 8.
 
 To benefit from configuration mutability support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_optional.adoc
+++ b/content/documentation/extensions/mod_optional.adoc
@@ -31,7 +31,7 @@ The module is based on Java 8.
 
 To use Tamaya _optional_ you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_osgi.adoc
+++ b/content/documentation/extensions/mod_osgi.adoc
@@ -37,7 +37,7 @@ is tested against the following OSGI runtimes:
 To benefit from Tamaya in an OSGI context you must deploy at least the following modules to
 your OSGI runtime environment:
 
-[source, listing]
+[source, listing, subs=attributes+]
 -----------------------------------------------
 # Runtime with OSGI ConfigAdmin support, e.g.
 org.apache.felix:org.apache.felix.configadmin:{felix_version}

--- a/content/documentation/extensions/mod_remote.adoc
+++ b/content/documentation/extensions/mod_remote.adoc
@@ -28,7 +28,7 @@ The module is based on Java 7, so it will not run on Java 7 and beyond.
 
 To use remote support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_resolver.adoc
+++ b/content/documentation/extensions/mod_resolver.adoc
@@ -28,7 +28,7 @@ The module is based on Java 8.
 
 To benefit from dynamic value resolution you only must add the corresponding dependency to your module:
 
-[source, xml, subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_resources.adoc
+++ b/content/documentation/extensions/mod_resources.adoc
@@ -24,7 +24,7 @@ The module is based on Java 8.
 
 To use this module add the following dependency:
 
-[source, listing, subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <grooupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_server.adoc
+++ b/content/documentation/extensions/mod_server.adoc
@@ -27,7 +27,7 @@ The module is based on Java 7, so it will not run on Java 7 and beyond.
 
 To benefit from configuration server support you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_spring.adoc
+++ b/content/documentation/extensions/mod_spring.adoc
@@ -35,7 +35,7 @@ Spring Framework as well as Spring Boot.
 
 To benefit from Tamaya Spring integration add the following dependencies to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_usagetracker.adoc
+++ b/content/documentation/extensions/mod_usagetracker.adoc
@@ -27,7 +27,7 @@ The module is based on Java 8.
 
 To use Tamaya _usagetracker_ you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_validation.adoc
+++ b/content/documentation/extensions/mod_validation.adoc
@@ -27,7 +27,7 @@ The module is based on Java 8.
 
 To activate configuration _validation_ you only must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_vertx.adoc
+++ b/content/documentation/extensions/mod_vertx.adoc
@@ -30,7 +30,7 @@ The module requires Java 8.
 To use Tamaya's _Vertx_ support you only must add the corresponding dependency to
 your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/extensions/mod_yaml.adoc
+++ b/content/documentation/extensions/mod_yaml.adoc
@@ -27,7 +27,7 @@ The YAML module is based on Java 8.
 
 To use YAML as configuration format you must add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya.ext</groupId>

--- a/content/documentation/quickstart.adoc
+++ b/content/documentation/quickstart.adoc
@@ -8,7 +8,7 @@ The fastest way to start with Tamaya is just using the _Core_ module, which
 provides a simple configuration API. To start add the following
 dependency to your project:
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 ----
 <dependency>
     <groupId>{tamaya_mvn_group_id}</groupId>
@@ -116,7 +116,7 @@ overview.
 
 ==== Dynamic Resolution and Value Placeholders
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 ----
 <dependency>
   <artifactId>org.apache.tamaya.ext</id>
@@ -140,7 +140,7 @@ String resolved = Resolver.getInstance().evaluateExpression(myExpression);
 
 ==== Ant-styled Path Resolution of Resources
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 ----
 <dependency>
   <artifactId>org.apache.tamaya.ext</id>
@@ -154,7 +154,7 @@ resolve configuration resources using a ant-styled resource
 description, e.g.
 
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml]
 ----
 Collection<URL> urls = Resolver.getInstance().getResources("META-INF/cfg/**/*.properties");
 ----
@@ -164,7 +164,7 @@ For further details refer to the module documentation.
 
 ==== Configuration Injection
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 ----
 <dependency>
   <artifactId>org.apache.tamaya.ext</id>
@@ -178,7 +178,7 @@ annotated classes or let Tamaya implement a configuration template.
 
 Corresponding configuration:
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml]
 ----
 public class MyType {
    @Config("my.key")
@@ -195,7 +195,7 @@ ConfigurationInjector.getInstance().configure(type);
 
 Or the same as template:
 
-[source,xml,subs="verbatim,attributes"]
+[source, xml]
 ----
 public interface MyTypeTemplate {
    @Config("my.key")

--- a/content/documentation/spisupport.adoc
+++ b/content/documentation/spisupport.adoc
@@ -51,7 +51,7 @@ The module is based on Java 8, so it will run on Java 8 and beyond.
 
 To use Tamaya's _spisupport_ you only have to add the corresponding dependency to your module:
 
-[source, xml]
+[source, xml, subs=attributes+]
 -----------------------------------------------
 <dependency>
   <groupId>org.apache.tamaya</groupId>

--- a/content/download.adoc
+++ b/content/download.adoc
@@ -32,7 +32,7 @@ Downloading of the the current state of the project can be done by
 
 // @todo Source highlighting does not work currently.
 //
-[source,xml,subs="verbatim,attributes"]
+[source, xml, subs=attributes+]
 ----
 <dependency>
     <groupId>{tamaya_mvn_group_id}</groupId>

--- a/jbake.properties
+++ b/jbake.properties
@@ -15,8 +15,8 @@ default.status=published
 template.encoding=UTF-8
 # Make properties available in templates
 asciidoctor.attributes.export=true
-asciidoctor.attributes.prefix=jbake-
 twitterhandle=tamayaconf
 tamaya_version_released=0.3-incubating
+tamaya_version_development=0.4-incubating-SNAPSHOT
 tamaya_version=0.4-incubating-SNAPSHOT
 tamaya_mvn_group_id=org.apache.tamaya


### PR DESCRIPTION
See https://github.com/asciidoctor/asciidoctor/issues/1741.

Turns out jbake was handing off the attributes to asciidoc just fine but
asciidoc doesn't interpolate those in source blocks by default. I added
the right command at the top of the blocks that contain jbake attributes, and
made some of the other blocks consistent.  Looks better in local testing
now.