### PR TITLE
TAMAYA-382 link updates

### DIFF
--- a/content/development/community.adoc
+++ b/content/development/community.adoc
@@ -16,7 +16,7 @@ project documentation. Apache Tamaya currently does
 not yet have a users mailing list. If you want discuss your use cases
 we encourage you to mailto:dev-subscribe@tamaya.incubator.apache.org[subscribe]
 to our mailto:dev@tamaya.incubator.apache.org[mailing list for developers].
-Furthermore, you can check our xref:a_mailing_lists[mail-archives].
+Furthermore, you can check our pass:[<a href="https://lists.apache.org/list.html?dev@tamaya.apache.org">mail-archives</a>].
 
 Before you file a ticket in our https://issues.apache.org/jira/browse/TAMAYA[Jira^]
 please ask on the mailing list if it's a known issue in case of a
@@ -65,7 +65,7 @@ start contributing and help users.
 
 Optionally mailto:commits-subscribe@tamaya.incubator.apache.org[subscribe] to our
 mailto:commits@tamaya.incubator.apache.org[mailing list for commits].
-Furthermore, you can check our link:community.html#mailing-lists[mail-archives].
+Furthermore, you can check our pass:[<a href="https://lists.apache.org/list.html?dev@tamaya.apache.org">mail-archives</a>].
 
 Further details are available at https://www.apache.org/dev/[https://www.apache.org/dev/^].
 

--- a/content/devguide.adoc
+++ b/content/devguide.adoc
@@ -14,7 +14,7 @@ or if your branch is ahead of master. This will always lead to
 some dirty artifacts in the commit history:
 
 ----
-Merge branch 'master' of http://gitbox.apache.org/tamaya into master
+Merge branch 'master' of https://github.com/apache/incubator-tamaya into master
 ----
 
 === Use git pull --rebase
@@ -171,7 +171,7 @@ as clean as possible.
 === Initial setup
 
 ----
-$ git clone https://gitbox.apache.org/repos/asf/incubator-tamaya.git
+$ git clone https://github.com/apache/incubator-tamaya.git
 $ git remote add discuss https://[username]@github.com/[username]/[repo-name].git
 $ git push -u discuss master
 ----

--- a/content/download.adoc
+++ b/content/download.adoc
@@ -10,7 +10,7 @@
 
 The latest release is Apache Tamaya {tamaya_version_released}.
 You can download it it from the
-http://www.apache.org/dist/incubator/tamaya[Apache Software Foundation Distribution Directory^].
+http://www.apache.org/dyn/closer.cgi/incubator/tamaya[Apache Software Foundation Distribution Directory^].
 
 The release notes for each release of Apache Tamaya
 can be found at the link:history.html[release history page].
@@ -19,7 +19,7 @@ can be found at the link:history.html[release history page].
 
 Downloading of the the current state of the project can be done by
 
-* cloning the https://github.com/apache/incubator-tamaya[GitHub mirror^]
+* cloning the https://github.com/apache/incubator-tamaya[GitHub repo^]
 * Github also provides an easy way to dowload the current project source as zip archive.
 // @todo * Cloning the Apache source tree, see link:3[source section]. source.html
 
@@ -50,7 +50,7 @@ Downloading of the the current state of the project can be done by
 == Previous Releases
 
 All previous releases can also be found at the
-https://www.apache.org/dist/incubator/tamaya/[Apache Software Foundation Distribution Directory^].
+https://archive.apache.org/dist/incubator/tamaya/[Apache Software Foundation Distribution Archive^].
 In our link:history.html[release history overview] you can find all previous releases of Tamaya.
 
 == Verifying Releases
@@ -66,7 +66,7 @@ as well as the asc signature file for the artifact. Make sure you get
 these files from the
 https://www.apache.org/dist/incubator/tamaya/[main distribution directory^]
 rather than from a
-https://www.apache.org/dyn/closer.cgi/tamaya/[mirror^].
+https://www.apache.org/dyn/closer.cgi/incubator/tamaya/[mirror^].
 Then verify the signatures using e.g.:
 
 [source,shell]

--- a/content/history.adoc
+++ b/content/history.adoc
@@ -19,16 +19,16 @@ Overview of all released versions of Apache Tamaya.
 | 0.3-incubating
 | 2016-09-12
 | n/a
-| https://www.apache.org/dist/incubator/tamaya/0.3-incubating/[Download of 0.3 incubating^]
+| https://archive.apache.org/dist/incubator/tamaya/0.3-incubating/[Download of 0.3 incubating^]
 
 | 0.2-incubating
 | 2016-04-06
-| https://www.apache.org/dist/incubator/tamaya/0.2-incubating/ReleaseNotes-0.2-incubating.html[Release Notes for 0.2 incubating^]
-| https://www.apache.org/dist/incubator/tamaya/0.2-incubating/[Download of 0.2 incubating^]
+| https://archive.apache.org/dist/incubator/tamaya/0.2-incubating/ReleaseNotes-0.2-incubating.html[Release Notes for 0.2 incubating^]
+| https://archive.apache.org/dist/incubator/tamaya/0.2-incubating/[Download of 0.2 incubating^]
 
 | 0.1-incubating
 | 2015-08-22
-| https://www.apache.org/dist/incubator/tamaya/0.1-incubating/ReleaseNotes-0.1-incubating.html[Release Notes for 0.1 incubating^]
-| https://www.apache.org/dist/incubator/tamaya/0.1-incubating/[Download of 0.1 incubating^]
+| https://archive.apache.org/dist/incubator/tamaya/0.1-incubating/ReleaseNotes-0.1-incubating.html[Release Notes for 0.1 incubating^]
+| https://archive.apache.org/dist/incubator/tamaya/0.1-incubating/[Download of 0.1 incubating^]
 
 |===

--- a/content/release-guide.adoc
+++ b/content/release-guide.adoc
@@ -416,13 +416,11 @@ general@incubator.apache.org.
 More information and how to do this can be found on
 https://incubator.apache.org/guides/lists.html[^].
 
-:x: https://lists.apache.org/list.html?dev@tamaya.apache.org
-
 The mail, which must be send to the list, is quite similar
 to the one for the PPMC, but it must also contain a link
 to the mail thread of the successful vote of the PPMC.
 The archive of the developers mailinglist of Apache Tamaya
-can be found at https://lists.apache.org[^].
+can be found at pass:[<a href="https://lists.apache.org/list.html?dev@tamaya.apache.org">https://lists.apache.org</a>].
 
 The mail to the IPMC can be composed by using these both
 templates:
@@ -623,7 +621,7 @@ If the directory does not exists, create it.
 [listing,text]
 .Creating the directory for the version of the release
 ----
-$ svn mkdir https://dist.apache.org/repos/dist/release/incubator/tamaya/[versio]    <1>
+$ svn mkdir https://dist.apache.org/repos/dist/release/incubator/tamaya/[version]    <1>
 ----
 <1> Replace _version_ by the version number of the release.
 


### PR DESCRIPTION
This PR makes 2 changes, per the February 2019 report.

1.  Updates artifact download links to use the mirror lookup link or
archive link as makes sense.
2.  Updates mail-archive link to work around problems putting the '@'
symbol in links in Asciidoc, but with the Apache list server not
accepting any encoded values in the URL.

I also changed a reference from apache gitbox over to github for new
devs, which seems in line with the move we made last year.